### PR TITLE
Cleanup plugin interface

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -37,6 +37,8 @@ var (
 	ErrPluginInitialized = errors.New("plugin: already initialized")
 	// ErrPluginNotFound is used when a plugin is looked up but not found
 	ErrPluginNotFound = errors.New("plugin: not found")
+	// ErrPluginMultipleInstances is used when a plugin is expected a single instance but has multiple
+	ErrPluginMultipleInstances = errors.New("plugin: multiple instances")
 
 	// ErrInvalidRequires will be thrown if the requirements for a plugin are
 	// defined in an invalid manner.


### PR DESCRIPTION
Separate Get for set and init context, which are used differently.
Ensure init context always returns instances and does not return an underlying map.

Update these interfaces before tagging v0.1.0 release

Related to https://github.com/containerd/containerd/pull/9258