### PR TITLE
Add meta callback to get plugin state

### DIFF
--- a/context.go
+++ b/context.go
@@ -57,6 +57,7 @@ type Meta struct {
 	Platforms    []imagespec.Platform // platforms supported by plugin
 	Exports      map[string]string    // values exported by plugin
 	Capabilities []string             // feature switches for plugin
+	State        func() interface{}   // callback to get a plugin state object
 }
 
 // Plugin represents an initialized plugin, used with an init context.


### PR DESCRIPTION
Allows plugins to return a runtime state object which could be used to return internal configuration state or other state related to a loaded and initialized plugin.